### PR TITLE
Change Embedder import to on-demand

### DIFF
--- a/deepsort_tracker.py
+++ b/deepsort_tracker.py
@@ -8,13 +8,11 @@ try:
     from deep_sort import nn_matching
     from deep_sort.detection import Detection
     from deep_sort.tracker import Tracker
-    from embedder_pytorch import MobileNetv2_Embedder as Embedder
     from utils.nms import non_max_suppression
 except:
     from .deep_sort import nn_matching
     from .deep_sort.detection import Detection
     from .deep_sort.tracker import Tracker
-    from .embedder_pytorch import MobileNetv2_Embedder as Embedder
     from .utils.nms import non_max_suppression
 
 log_level = logging.DEBUG
@@ -68,6 +66,10 @@ class DeepSort(object):
             "cosine", max_cosine_distance, nn_budget)
         self.tracker = Tracker(metric, max_age = max_age, override_track_class=override_track_class, clock=clock, logger=self.logger)
         if embedder:
+            try:
+                from embedder_pytorch import MobileNetv2_Embedder as Embedder
+            except:
+                from .embedder_pytorch import MobileNetv2_Embedder as Embedder
             self.embedder = Embedder(half=half, max_batch_size=16, bgr=bgr)
         else:
             self.embedder = None


### PR DESCRIPTION
Currently the file imports Embedder even if it's not in use. This is an issue if we are using an external embedder and do not have PyTorch/Tensorflow installed. It also bloats up the process memory unnecessarily.
This commit changes the import to happen only if the Embedder is required.