### PR TITLE
improve cpu performance - added longdouble to cosine distance calc

### DIFF
--- a/deep_sort_realtime/deep_sort/nn_matching.py
+++ b/deep_sort_realtime/deep_sort/nn_matching.py
@@ -49,8 +49,8 @@ def _cosine_distance(a, b, data_is_normalized=False):
 
     """
     if not data_is_normalized:
-        a = np.asarray(a) / np.linalg.norm(a, axis=1, keepdims=True)
-        b = np.asarray(b) / np.linalg.norm(b, axis=1, keepdims=True)
+        a = np.asarray(a, dtype=np.longdouble) / np.linalg.norm(a, axis=1, keepdims=True)
+        b = np.asarray(b, dtype=np.longdouble) / np.linalg.norm(b, axis=1, keepdims=True)
     return 1.0 - np.dot(a, b.T)
 
 


### PR DESCRIPTION
During the tracking loop cpu usage was often over 700%, this change decreased it by over half in my use case.
- The cosine distance gets calculated similarly to [this](https://github.com/mikel-brostrom/boxmot/issues/48) ticket.
- Chose to utilize longdouble instead of float128 to keep repo working on windows.