### PR TITLE
Improve device support for MacOS MPS

### DIFF
--- a/deep_sort_realtime/embedder/__init__.py
+++ b/deep_sort_realtime/embedder/__init__.py
@@ -4,21 +4,28 @@ import torch
 def get_best_device(gpu=True):
     """Determine the best available torch device.
 
-    Priority: CUDA > MPS > CPU (when gpu=True).
-    Returns 'cpu' when gpu=False.
+    Uses torch.accelerator (PyTorch >= 2.4) to detect any supported accelerator
+    (CUDA, MPS, XPU, HPU, etc.). Falls back to manual checks for older PyTorch.
+    Returns 'cpu' when gpu=False or no accelerator is available.
 
     Parameters
     ----------
     gpu : bool
-        Whether to attempt to use a GPU device. If False, always returns 'cpu'.
+        Whether to attempt to use an accelerator device. If False, always returns 'cpu'.
 
     Returns
     -------
     str
-        One of 'cuda', 'mps', or 'cpu'.
+        Device type string, e.g. 'cuda', 'mps', 'xpu', or 'cpu'.
     """
     if not gpu:
         return "cpu"
+    # torch.accelerator (PyTorch >= 2.4) provides unified detection across all backends
+    if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "is_available"):
+        if torch.accelerator.is_available():
+            return torch.accelerator.current_accelerator().type
+        return "cpu"
+    # Fallback for PyTorch < 2.4
     if torch.cuda.is_available():
         return "cuda"
     if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():

--- a/deep_sort_realtime/embedder/__init__.py
+++ b/deep_sort_realtime/embedder/__init__.py
@@ -21,8 +21,10 @@ def get_best_device(gpu=True):
     # torch.accelerator (PyTorch >= 2.4) provides unified detection across all backends
     if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "is_available"):
         if torch.accelerator.is_available():
-            return torch.accelerator.current_accelerator().type
-        return "cpu"
+            try:
+                return torch.accelerator.current_accelerator().type
+            except RuntimeError:
+                pass  # fall through to manual checks below
     # Fallback for PyTorch < 2.4
     if torch.cuda.is_available():
         return "cuda"

--- a/deep_sort_realtime/embedder/__init__.py
+++ b/deep_sort_realtime/embedder/__init__.py
@@ -1,6 +1,3 @@
-import torch
-
-
 def get_best_device(gpu=True):
     """Determine the best available torch device.
 
@@ -20,6 +17,7 @@ def get_best_device(gpu=True):
     """
     if not gpu:
         return "cpu"
+    import torch
     # torch.accelerator (PyTorch >= 2.4) provides unified detection across all backends
     if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "is_available"):
         if torch.accelerator.is_available():

--- a/deep_sort_realtime/embedder/__init__.py
+++ b/deep_sort_realtime/embedder/__init__.py
@@ -1,0 +1,26 @@
+import torch
+
+
+def get_best_device(gpu=True):
+    """Determine the best available torch device.
+
+    Priority: CUDA > MPS > CPU (when gpu=True).
+    Returns 'cpu' when gpu=False.
+
+    Parameters
+    ----------
+    gpu : bool
+        Whether to attempt to use a GPU device. If False, always returns 'cpu'.
+
+    Returns
+    -------
+    str
+        One of 'cuda', 'mps', or 'cpu'.
+    """
+    if not gpu:
+        return "cpu"
+    if torch.cuda.is_available():
+        return "cuda"
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"

--- a/deep_sort_realtime/embedder/embedder_clip.py
+++ b/deep_sort_realtime/embedder/embedder_clip.py
@@ -9,6 +9,8 @@ import pkg_resources
 import torch
 from PIL import Image
 
+from deep_sort_realtime.embedder import get_best_device
+
 logger = logging.getLogger(__name__)
 
 
@@ -51,7 +53,7 @@ class Clip_Embedder(object):
             else:
                 model_wts_path = model_name
 
-        self.device = "cuda" if gpu else "cpu"
+        self.device = get_best_device(gpu)
         self.model, self.img_preprocess = clip.load(model_wts_path, device=self.device)
         self.model.eval()
 
@@ -59,7 +61,7 @@ class Clip_Embedder(object):
         self.bgr = bgr
 
         logger.info("Clip Embedder for Deep Sort initialised")
-        logger.info(f"- gpu enabled: {gpu}")
+        logger.info(f"- device: {self.device}")
         logger.info(f"- max batch size: {self.max_batch_size}")
         logger.info(f"- expects BGR: {self.bgr}")
         logger.info(f"- model name: {model_name}")

--- a/deep_sort_realtime/embedder/embedder_pytorch.py
+++ b/deep_sort_realtime/embedder/embedder_pytorch.py
@@ -7,6 +7,7 @@ import pkg_resources
 import torch
 from torchvision.transforms import transforms
 
+from deep_sort_realtime.embedder import get_best_device
 from deep_sort_realtime.embedder.mobilenetv2_bottle import MobileNetV2_bottle
 
 logger = logging.getLogger(__name__)
@@ -49,15 +50,19 @@ class MobileNetv2_Embedder(object):
         assert os.path.exists(
             model_wts_path
         ), f"Mobilenetv2 model path {model_wts_path} does not exists!"
+        self.device = get_best_device(gpu)
         self.model = MobileNetV2_bottle(input_size=INPUT_WIDTH, width_mult=1.0)
-        self.model.load_state_dict(torch.load(model_wts_path))
+        self.model.load_state_dict(
+            torch.load(model_wts_path, map_location=self.device)
+        )
 
-        self.gpu = gpu and torch.cuda.is_available()
-        if self.gpu:
-            self.model.cuda()  # loads model to gpu
-            self.half = half
-            if self.half:
-                self.model.half()
+        self.gpu = self.device != "cpu"
+        self.model.to(self.device)
+
+        # Half precision: only enable on CUDA (MPS has limited float16 support)
+        if self.device == "cuda" and half:
+            self.half = True
+            self.model.half()
         else:
             self.half = False
 
@@ -67,7 +72,7 @@ class MobileNetv2_Embedder(object):
         self.bgr = bgr
 
         logger.info("MobileNetV2 Embedder for Deep Sort initialised")
-        logger.info(f"- gpu enabled: {self.gpu}")
+        logger.info(f"- device: {self.device}")
         logger.info(f"- half precision: {self.half}")
         logger.info(f"- max batch size: {self.max_batch_size}")
         logger.info(f"- expects BGR: {self.bgr}")
@@ -129,7 +134,7 @@ class MobileNetv2_Embedder(object):
         for this_batch in batch(preproc_imgs, bs=self.max_batch_size):
             this_batch = torch.cat(this_batch, dim=0)
             if self.gpu:
-                this_batch = this_batch.cuda()
+                this_batch = this_batch.to(self.device)
                 if self.half:
                     this_batch = this_batch.half()
             output = self.model.forward(this_batch)
@@ -171,11 +176,9 @@ class TorchReID_Embedder(object):
         if model_name=='osnet_ain_x1_0' and model_wts_path=='':
             model_wts_path = TORCHREID_OSNET_AIN_X1_0_MS_D_C_WTS
 
-        self.gpu = gpu and torch.cuda.is_available()
-        if self.gpu:
-            device = 'cuda'
-        else:
-            device = 'cpu'
+        self.device = get_best_device(gpu)
+        self.gpu = self.device != 'cpu'
+        device = self.device
 
         self.model = FeatureExtractor(
             model_name=model_name, 
@@ -186,7 +189,7 @@ class TorchReID_Embedder(object):
         self.bgr = bgr
 
         logger.info("TorchReID Embedder for Deep Sort initialised")
-        logger.info(f"- gpu enabled: {self.gpu}")
+        logger.info(f"- device: {self.device}")
         logger.info(f"- expects BGR: {self.bgr}")
 
         zeros = np.zeros((100, 100, 3), dtype=np.uint8)

--- a/test/test_bb.py
+++ b/test/test_bb.py
@@ -6,10 +6,13 @@ from datetime import datetime
 try:
     import torch
 
-    GPU = (
-        torch.cuda.is_available()
-        or (hasattr(torch.backends, "mps") and torch.backends.mps.is_available())
-    ) and not os.environ.get("USE_CPU")
+    if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "is_available"):
+        GPU = torch.accelerator.is_available()
+    else:
+        GPU = torch.cuda.is_available() or (
+            hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+        )
+    GPU = GPU and not os.environ.get("USE_CPU")
     TORCH_INSTALLED = True
 except ModuleNotFoundError:
     GPU = False

--- a/test/test_bb.py
+++ b/test/test_bb.py
@@ -6,7 +6,10 @@ from datetime import datetime
 try:
     import torch
 
-    GPU = torch.cuda.is_available() and not os.environ.get("USE_CPU")
+    GPU = (
+        torch.cuda.is_available()
+        or (hasattr(torch.backends, "mps") and torch.backends.mps.is_available())
+    ) and not os.environ.get("USE_CPU")
     TORCH_INSTALLED = True
 except ModuleNotFoundError:
     GPU = False

--- a/test/test_embedder.py
+++ b/test/test_embedder.py
@@ -8,9 +8,12 @@ try:
     import torch
 
     TORCH_INSTALLED = True
-    GPU = torch.cuda.is_available() or (
-        hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
-    )
+    if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "is_available"):
+        GPU = torch.accelerator.is_available()
+    else:
+        GPU = torch.cuda.is_available() or (
+            hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+        )
 except ModuleNotFoundError:
     TORCH_INSTALLED = False
     CLIP_INSTALLED = False

--- a/test/test_embedder.py
+++ b/test/test_embedder.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from pathlib import Path
 
@@ -14,6 +15,7 @@ try:
         GPU = torch.cuda.is_available() or (
             hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
         )
+    GPU = GPU and not os.environ.get("USE_CPU")
 except ModuleNotFoundError:
     TORCH_INSTALLED = False
     CLIP_INSTALLED = False

--- a/test/test_embedder.py
+++ b/test/test_embedder.py
@@ -8,10 +8,13 @@ try:
     import torch
 
     TORCH_INSTALLED = True
-    GPU = torch.cuda.is_available()
+    GPU = torch.cuda.is_available() or (
+        hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+    )
 except ModuleNotFoundError:
     TORCH_INSTALLED = False
     CLIP_INSTALLED = False
+    TORCHREID_INSTALLED = False
     GPU = False
 
 if TORCH_INSTALLED:

--- a/test/test_general.py
+++ b/test/test_general.py
@@ -5,10 +5,13 @@ from datetime import datetime
 try:
     import torch
 
-    GPU = (
-        torch.cuda.is_available()
-        or (hasattr(torch.backends, "mps") and torch.backends.mps.is_available())
-    ) and not os.environ.get("USE_CPU")
+    if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "is_available"):
+        GPU = torch.accelerator.is_available()
+    else:
+        GPU = torch.cuda.is_available() or (
+            hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+        )
+    GPU = GPU and not os.environ.get("USE_CPU")
     TORCH_INSTALLED = True
 except ModuleNotFoundError:
     GPU = False

--- a/test/test_general.py
+++ b/test/test_general.py
@@ -5,7 +5,10 @@ from datetime import datetime
 try:
     import torch
 
-    GPU = torch.cuda.is_available() and not os.environ.get("USE_CPU")
+    GPU = (
+        torch.cuda.is_available()
+        or (hasattr(torch.backends, "mps") and torch.backends.mps.is_available())
+    ) and not os.environ.get("USE_CPU")
     TORCH_INSTALLED = True
 except ModuleNotFoundError:
     GPU = False


### PR DESCRIPTION
**Device selection improvements:**

* Added a new `get_best_device` function in `deep_sort_realtime/embedder/__init__.py` to select the best available device (supports PyTorch >=2.4 accelerators, falls back to CUDA/MPS checks for older versions).
* Refactored embedders (`embedder_clip.py` and `embedder_pytorch.py`) to use `get_best_device`, replacing direct CUDA checks and improving device logging. [[1]](diffhunk://#diff-024a0df6345535d4367a98fa107a72d2cec14a595a64ace28d95d917ab9cd2b5R12-R13) [[2]](diffhunk://#diff-024a0df6345535d4367a98fa107a72d2cec14a595a64ace28d95d917ab9cd2b5L54-R64) [[3]](diffhunk://#diff-d61d32a9fc4bdb7c6e776a48051817ce4db94783c5f6953ff6ef108edcd54bc4R10) [[4]](diffhunk://#diff-d61d32a9fc4bdb7c6e776a48051817ce4db94783c5f6953ff6ef108edcd54bc4R53-R64) [[5]](diffhunk://#diff-d61d32a9fc4bdb7c6e776a48051817ce4db94783c5f6953ff6ef108edcd54bc4L70-R75) [[6]](diffhunk://#diff-d61d32a9fc4bdb7c6e776a48051817ce4db94783c5f6953ff6ef108edcd54bc4L174-R181) [[7]](diffhunk://#diff-d61d32a9fc4bdb7c6e776a48051817ce4db94783c5f6953ff6ef108edcd54bc4L189-R192) [[8]](diffhunk://#diff-d61d32a9fc4bdb7c6e776a48051817ce4db94783c5f6953ff6ef108edcd54bc4L132-R137)

**Test robustness:**

* Updated device/GPU detection logic in test files (`test_bb.py`, `test_embedder.py`, `test_general.py`) to use the same accelerator-aware checks, ensuring tests correctly detect available hardware across platforms and PyTorch versions. [[1]](diffhunk://#diff-521891349b31cba559345cb23c0813521d3b1aec32a46a58318623f90e34d9f4L9-R15) [[2]](diffhunk://#diff-267f9df08865f56a42a41c9ad5a1dc1f494ff24c8fe36cd1d3e4c5fb75db076aL11-R20) [[3]](diffhunk://#diff-7b3ef499976262ce48ea806e4b60e108f4a7121432d31a2f82da985accf72febL8-R14)

These changes increase hardware compatibility and future-proof the codebase for upcoming PyTorch releases.